### PR TITLE
feat: 增加 macOS（OrbStack / Docker Desktop）部署脚本及 README 使用说明

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # ARL(灯塔）-docker版(已支持Linux和macos)
 
 本项目基于渊龙团队备份：[ARL](https://github.com/Aabyss-Team/ARL) v2.6.2版本源码，制作成docker镜像进行快速部署。
-> macOS 用户请直接滑至文末查看 [Mac 适配部署指南](#macos-快速部署指南)
+> macOS 用户请直接滑至文末查看 [Mac 适配部署指南](#macos-快速部署指南-适配-orbstack--docker-desktop)
 
 1.  提供自选指纹是否添加方案，可根据需求选择。
 2.  请注意，添加指纹的工具借用的是 ARL-Finger-ADD ，但指纹不是哦，由多处获取，经过格式转换、指纹去重后保留下来的一批指纹，原指纹量达到6w+但其实重复极多。

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # 给孩子点点 Star 吧，求求了，其他项目也可以看看，点点 Star ~
 
-# ARL(灯塔）-docker版
+# ARL(灯塔）-docker版(已支持Linux和macos)
 
 本项目基于渊龙团队备份：[ARL](https://github.com/Aabyss-Team/ARL) v2.6.2版本源码，制作成docker镜像进行快速部署。
+> macOS 用户请直接滑至文末查看 [Mac 适配部署指南](#macos-快速部署指南)
 
 1.  提供自选指纹是否添加方案，可根据需求选择。
 2.  请注意，添加指纹的工具借用的是 ARL-Finger-ADD ，但指纹不是哦，由多处获取，经过格式转换、指纹去重后保留下来的一批指纹，原指纹量达到6w+但其实重复极多。
@@ -20,6 +21,7 @@
 添加运行权限： `chmod +x setup_docker.sh`
 
 执行部署脚本：`bash setup_docker.sh`
+
 
 ![Clip_2024-07-31_18-21-38](https://github.com/user-attachments/assets/53a11bbb-599c-453c-b302-45d4c63dcfb8)
 
@@ -83,3 +85,17 @@ Github：https://github.com/honmashironeko/icpscan/releases
 启动 ARL 命令：`docker-compose up -d`
 
 编辑配置文件：`vi config-docker.yaml`
+
+---
+
+## macos 快速部署指南 (适配 OrbStack / Docker Desktop）
+> 建议对终端开网络代理
+
+感谢 @lixiasky 适配支持，macOS 用户可使用以下命令快速部署 ARL：
+
+```bash
+git clone https://github.com/honmashironeko/ARL-docker.git
+cd ARL-docker/
+chmod +x setup_mac_docker.sh
+bash setup_mac_docker.sh
+```

--- a/setup_mac_docker.sh
+++ b/setup_mac_docker.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+echo "Docker 镜像作者：本间白猫"
+echo "❗️ 本脚本完全基于 <Docker 镜像作者：本间白猫> 的 setup_docker.sh 适配macOS"
+echo "🎉 欢迎使用 ARL Mac 快速部署脚本 by lixiasky & 本间白猫"
+echo "🌐 项目地址：https://github.com/honmashironeko/ARL-docker"
+echo ""
+
+# 提醒用户已经准备好了 Docker（由 OrbStack 或 Docker Desktop 提供）
+echo "✅ 请确保你已正确安装 Docker，并在运行状态"
+docker -v || { echo "❌ 未检测到 Docker，请先安装 Docker 后再运行本脚本"; exit 1; }
+
+echo ""
+read -p "是否继续部署 ARL？[Y/n]: " confirm
+confirm=${confirm:-Y}
+
+if [[ "$confirm" != "Y" && "$confirm" != "y" ]]; then
+  echo "🚫 已取消部署。"
+  exit 0
+fi
+
+echo "📦 开始创建数据库卷..."
+docker volume create --name=arl_db
+
+echo "🚀 启动 ARL 容器..."
+docker-compose up -d || {
+  echo "❌ Docker Compose 启动失败，请检查是否安装 docker-compose 工具"
+  exit 1
+}
+
+echo ""
+read -p "是否添加指纹测试数据？[Y/n]: " addfinger
+addfinger=${addfinger:-Y}
+
+if [[ "$addfinger" == "Y" || "$addfinger" == "y" ]]; then
+  echo "🐍 检测 Python3 安装状态..."
+  if ! command -v python3 >/dev/null 2>&1; then
+    echo "❌ 未检测到 Python3，请先安装 Python3"
+    exit 1
+  fi
+
+  echo "📦 正在安装 requests 库（如已安装会跳过）..."
+  pip3 install requests --user
+
+  echo "📥 运行指纹添加脚本..."
+  python3 ARL-Finger-ADD.py https://127.0.0.1:5003/ admin honmashironeko
+else
+  echo "🚫 跳过指纹添加"
+fi
+
+echo ""
+echo "🎉 ARL 部署完成，请访问："
+echo "🔗 http://localhost:5003"
+echo "🔐 默认账号：admin / honmashironeko"
+echo ""
+echo "✨ 感谢你的使用，记得 Star 一下原项目支持作者鸭~"
+echo "🔗 原作者信息:"
+echo "已完成ARL部署，感谢您的使用，如果对您有帮助，请给我们点个赞，谢谢！"
+echo "Github：https://github.com/honmashironeko/ARL-docker"
+echo "博客：https://y.shironekosan.cn" 
+echo "公众号：樱花庄的本间白猫"


### PR DESCRIPTION
### 💡 更新说明：

- 新增适配 macOS 的部署脚本 `setup_mac_docker.sh`，支持在 OrbStack / Docker Desktop 环境中一键部署 ARL。
> `setup_mac_docker.sh` (已适配 macOS 环境并实测可用(如遇失败，可尝试对终端开启代理)
- 不修改项目原始代码，所有适配逻辑仅限于脚本层。
- 在 README 中新增了《Mac 快速部署指南》章节，并加入跳转链接，便于 macOS 用户快速查阅和使用。

✨ 感谢本间白猫大佬提供的原始镜像与脚本！  
🎉 希望这个 PR 能帮助更多 macOS 平台的同学更便捷地使用 ARL！

By：lixiasky 